### PR TITLE
feat (ObviousComment): Support additional keyword triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ existing `enabled` list:
 {ExSlop.Check.Readability.NarratorDoc, []},
 {ExSlop.Check.Readability.DocFalseOnPublicFunction, []},
 {ExSlop.Check.Readability.BoilerplateDocParams, []},
-{ExSlop.Check.Readability.ObviousComment, []},
+{ExSlop.Check.Readability.ObviousComment, [additional_keywords: []]},
 {ExSlop.Check.Readability.StepComment, []},
 {ExSlop.Check.Readability.NarratorComment, []}
 ```

--- a/lib/ex_slop/check/readability/obvious_comment.ex
+++ b/lib/ex_slop/check/readability/obvious_comment.ex
@@ -4,6 +4,7 @@ defmodule ExSlop.Check.Readability.ObviousComment do
     base_priority: :low,
     category: :readability,
     tags: [:ex_slop],
+    param_defaults: [additional_keywords: []],
     explanations: [
       check: """
       Comments that restate what the next line of code does are noise.
@@ -25,7 +26,11 @@ defmodule ExSlop.Check.Readability.ObviousComment do
           # good — explains HOW or WHY (not flagged despite starting with "Fetch")
           # Fetch the connection from the pool, blocking up to 5s
           conn = ConnectionPool.checkout!(pool, timeout: 5_000)
-      """
+      """,
+      params: [
+        additional_keywords:
+          "Additional string prefixes or regexes to match against the comment text after `# `."
+      ]
     ]
 
   @obvious_pattern ~r/\A\s*#\s*(?:Fetch|Get|Create|Build|Update|Delete|Remove|Set|Parse|Convert|Validate|Check|Process|Handle|Format|Transform|Normalize|Calculate|Compute|Extract|Initialize|Define|Assign|Store|Save|Insert|Add|Return|Ensure|Verify)\s+(?:the|a|an)\s/i
@@ -39,6 +44,11 @@ defmodule ExSlop.Check.Readability.ObviousComment do
   @doc false
   @impl true
   def run(%SourceFile{} = source_file, params) do
+    additional_keywords = Params.get(params, :additional_keywords, __MODULE__)
+
+    {additional_prefixes, additional_regexes} =
+      Enum.split_with(additional_keywords, &is_binary/1)
+
     ctx = Context.build(source_file, params, __MODULE__)
     doc_ranges = ExSlop.DocRanges.build(Credo.SourceFile.source(source_file))
 
@@ -47,7 +57,8 @@ defmodule ExSlop.Check.Readability.ObviousComment do
     |> Enum.reduce(ctx, fn {line_no, line}, ctx ->
       trimmed = String.trim(line)
 
-      if not ExSlop.DocRanges.inside_doc?(line_no, doc_ranges) and obvious?(trimmed) do
+      if not ExSlop.DocRanges.inside_doc?(line_no, doc_ranges) and
+           obvious?(trimmed, additional_prefixes, additional_regexes) do
         put_issue(ctx, issue_for(ctx, line_no))
       else
         ctx
@@ -56,15 +67,21 @@ defmodule ExSlop.Check.Readability.ObviousComment do
     |> Map.get(:issues, [])
   end
 
-  defp obvious?(line) do
+  defp obvious?(line, additional_prefixes, additional_regexes) do
     comment_body = extract_comment_body(line)
 
     comment_body != nil and
       String.length(comment_body) < @max_obvious_length and
-      Regex.match?(@obvious_pattern, line) and
+      obvious_trigger?(line, comment_body, additional_prefixes, additional_regexes) and
       not has_technical_detail?(comment_body) and
       not Regex.match?(@keeper_pattern, line) and
       not Regex.match?(@tool_directive, line)
+  end
+
+  defp obvious_trigger?(line, comment_body, additional_prefixes, additional_regexes) do
+    Regex.match?(@obvious_pattern, line) or
+      String.starts_with?(comment_body, additional_prefixes) or
+      Enum.any?(additional_regexes, &Regex.match?(&1, comment_body))
   end
 
   defp extract_comment_body(line) do

--- a/test/checks/readability/obvious_comment_test.exs
+++ b/test/checks/readability/obvious_comment_test.exs
@@ -114,4 +114,49 @@ defmodule ExSlop.Check.Readability.ObviousCommentTest do
     |> run_check(ObviousComment)
     |> refute_issues()
   end
+
+  test "reports configured string prefix" do
+    """
+    defmodule Test do
+      def foo do
+        # Hydrate the cache
+        hydrate_cache()
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(ObviousComment, additional_keywords: ["Hydrate the"])
+    |> assert_issue()
+  end
+
+  test "reports configured regex" do
+    """
+    defmodule Test do
+      def foo do
+        # Hydrate the cache
+        hydrate_cache()
+
+        # Hydrate something else (this one shouldn't be flagged)
+        hydrate_something_else()
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(ObviousComment, additional_keywords: [~r/\AHydrate\s+(?:the|a|an)\s/i])
+    |> assert_issue()
+  end
+
+  test "does NOT report configured string when it is not at the comment start" do
+    """
+    defmodule Test do
+      def foo do
+        # We should hydrate the cache
+        hydrate_cache()
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(ObviousComment, additional_keywords: ["Hydrate the"])
+    |> refute_issues()
+  end
 end


### PR DESCRIPTION
Hi there! Thanks so much for these checks. We've gotten tremendous value out of them.

This adds a new configuration option to the `ObviousComment` check to allow users to specify additional triggers. For instance, in my codebase, I'd like to flag things like `# Assert [blah blah blah]` or `# Create user`, but the built-in regex doesn't include those. This provides additional flexibility for users without needing to upstream all possible variants of unnecessary comments.