### PR TITLE
Warn when plugin is registered but no checks are active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Warn when ExSlop is registered as a plugin but none of its checks are active. This happens when `.credo.exs` declares an explicit `checks.enabled` list (as `mix credo.gen.config` generates): Credo treats that list as authoritative and discards the plugin's registered checks, so the plugin silently contributes nothing. The warning points users to append `ExSlop.recommended_checks/0` to their `enabled` list. Also documented in the README installation section.
+
 ## 0.4.3
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,28 @@ Register the plugin in your `.credo.exs`:
 }
 ```
 
-This enables 31 high-signal checks automatically and leaves noisier style/performance checks opt-in. Or cherry-pick individual checks — append them to the `extra` list:
+This enables 31 high-signal checks automatically and leaves noisier style/performance checks opt-in.
+
+> [!IMPORTANT]
+> The `plugins:` line only enables the checks when your config does **not**
+> declare an explicit `checks.enabled` list. If you ran `mix credo.gen.config`,
+> your `.credo.exs` has a full `enabled:` list, and Credo treats it as
+> authoritative — it discards the checks the plugin registers, so the plugin
+> contributes nothing. Append the recommended set to your `enabled:` list
+> instead:
+>
+> ```elixir
+> checks: %{
+>   enabled: [
+>     # ...your existing checks...
+>   ] ++ Enum.map(ExSlop.recommended_checks(), &{&1, []}),
+>   # ...
+> }
+> ```
+>
+> ExSlop prints a warning when it detects this situation.
+
+Or cherry-pick individual checks — append them to the `extra` list:
 
 ```elixir
 # .credo.exs

--- a/lib/ex_slop.ex
+++ b/lib/ex_slop.ex
@@ -102,7 +102,9 @@ defmodule ExSlop do
   @default_config "%{configs: [%{name: \"default\", checks: %{extra: #{inspect(Enum.map(@recommended_checks, &{&1, []}))}}}]}"
 
   def init(exec) do
-    register_default_config(exec, @default_config)
+    exec
+    |> register_default_config(@default_config)
+    |> append_task(:validate_config, ExSlop.Plugin.ActivationWarning)
   end
 
   def checks, do: @checks

--- a/lib/ex_slop/plugin/activation_warning.ex
+++ b/lib/ex_slop/plugin/activation_warning.ex
@@ -1,13 +1,6 @@
 defmodule ExSlop.Plugin.ActivationWarning do
   @moduledoc """
   Warns when ExSlop is registered as a plugin but none of its checks are active.
-
-  This happens when the surrounding `.credo.exs` declares an explicit
-  `checks.enabled` list (as `mix credo.gen.config` generates): Credo treats that
-  list as authoritative and discards the `checks.extra` set the plugin registers
-  as default config, so the plugin silently contributes nothing. The fix is to
-  append `ExSlop.recommended_checks/0` to the `enabled` list — this task points
-  the user there instead of leaving them to discover it.
   """
 
   use Credo.Execution.Task
@@ -16,21 +9,19 @@ defmodule ExSlop.Plugin.ActivationWarning do
 
   @impl true
   def call(exec, _opts) do
-    unless active?(exec) do
-      warn()
-    end
+    if not active?(exec), do: warn()
 
     exec
   end
 
   @doc """
-  Returns `true` when at least one ExSlop check is in the resolved `enabled` set,
-  or when the check set can't be determined (in which case we stay quiet).
+  Returns `true` when at least one ExSlop check is in the resolved `enabled` set.
   """
   def active?(%Credo.Execution{checks: %{enabled: enabled}}) when is_list(enabled) do
     Enum.any?(enabled, fn {mod, _params} -> mod in ExSlop.checks() end)
   end
 
+  # Returns `true` when the ExSlop check set can't be determined
   def active?(_exec), do: true
 
   defp warn do

--- a/lib/ex_slop/plugin/activation_warning.ex
+++ b/lib/ex_slop/plugin/activation_warning.ex
@@ -1,0 +1,48 @@
+defmodule ExSlop.Plugin.ActivationWarning do
+  @moduledoc """
+  Warns when ExSlop is registered as a plugin but none of its checks are active.
+
+  This happens when the surrounding `.credo.exs` declares an explicit
+  `checks.enabled` list (as `mix credo.gen.config` generates): Credo treats that
+  list as authoritative and discards the `checks.extra` set the plugin registers
+  as default config, so the plugin silently contributes nothing. The fix is to
+  append `ExSlop.recommended_checks/0` to the `enabled` list — this task points
+  the user there instead of leaving them to discover it.
+  """
+
+  use Credo.Execution.Task
+
+  alias Credo.CLI.Output.UI
+
+  @impl true
+  def call(exec, _opts) do
+    unless active?(exec) do
+      warn()
+    end
+
+    exec
+  end
+
+  @doc """
+  Returns `true` when at least one ExSlop check is in the resolved `enabled` set,
+  or when the check set can't be determined (in which case we stay quiet).
+  """
+  def active?(%Credo.Execution{checks: %{enabled: enabled}}) when is_list(enabled) do
+    Enum.any?(enabled, fn {mod, _params} -> mod in ExSlop.checks() end)
+  end
+
+  def active?(_exec), do: true
+
+  defp warn do
+    UI.warn([
+      :yellow,
+      "warning: ",
+      :reset,
+      "ExSlop is registered as a plugin but none of its checks are active. ",
+      "Your `.credo.exs` declares an explicit `checks.enabled` list, which Credo ",
+      "treats as authoritative — the plugin's default checks are discarded. ",
+      "Append them to your `enabled` list:\n\n",
+      "    ] ++ Enum.map(ExSlop.recommended_checks(), &{&1, []}),\n"
+    ])
+  end
+end

--- a/test/plugin/activation_warning_test.exs
+++ b/test/plugin/activation_warning_test.exs
@@ -1,0 +1,33 @@
+defmodule ExSlop.Plugin.ActivationWarningTest do
+  use ExUnit.Case, async: true
+
+  alias ExSlop.Plugin.ActivationWarning
+
+  test "active? is true when an ExSlop check is enabled" do
+    exec = %Credo.Execution{
+      checks: %{
+        enabled: [{Credo.Check.Readability.ModuleDoc, []}, {ExSlop.Check.Refactor.RejectNil, []}]
+      }
+    }
+
+    assert ActivationWarning.active?(exec)
+  end
+
+  test "active? is false when only non-ExSlop checks are enabled" do
+    exec = %Credo.Execution{
+      checks: %{enabled: [{Credo.Check.Readability.ModuleDoc, []}]}
+    }
+
+    refute ActivationWarning.active?(exec)
+  end
+
+  test "active? stays quiet (true) when the check set is unknown" do
+    assert ActivationWarning.active?(%Credo.Execution{checks: nil})
+  end
+
+  test "call/2 returns the exec unchanged" do
+    exec = %Credo.Execution{checks: %{enabled: [{Credo.Check.Readability.ModuleDoc, []}]}}
+
+    assert ActivationWarning.call(exec, []) == exec
+  end
+end


### PR DESCRIPTION
## Problem - #6

Adding `{ExSlop, []}` to `plugins:` silently enables nothing when `.credo.exs` declares an explicit `checks.enabled` list. This is a common case: `mix credo.gen.config` generates exactly such a list, and most users run that to customise Credo.

The mechanism is Credo's config merge (`Credo.ConfigFile.merge_checks/2`): the plugin registers its checks as default config via `checks.extra`, but when the user's config has an explicit `enabled:` list, Credo treats that list as authoritative and discards the plugin's contribution. The plugin is inert, with no feedback to the user.

## Fix

Add a `:validate_config` pipeline task that runs after the config is resolved. If ExSlop is registered as a plugin but none of its checks are in the resolved `enabled` set, it prints a warning pointing the user to append `ExSlop.recommended_checks/0` to their `enabled:` list.

The README installation section now documents the gotcha alongside the `plugins:` snippet.

## Behaviour

Warns only in the clobber case. Verified with a path-dep consumer app:

- explicit `enabled:` list + plugin, no ExSlop checks → **warns**
- `enabled:` list with `recommended_checks/0` appended → quiet
- plugin-only config (no explicit `enabled:`) → quiet
- no plugin registered → quiet (task never runs)

## Tests

`mix test` (176 passing incl. 4 new), `mix format --check-formatted`, and `mix credo` all clean.

Closes #6
